### PR TITLE
Fix balances incorrect

### DIFF
--- a/app/src/components/private-layout/topbar/no-wallet-actions.vue
+++ b/app/src/components/private-layout/topbar/no-wallet-actions.vue
@@ -205,7 +205,7 @@ export default {
           this.wallets[w].address,
         );
         if(responseBalances.data.result.length){
-          total += parseInt(responseBalances.data.result.find(balance => balance.denom === 'uxdki').amount);
+          total += parseInt(responseBalances.data.result.find(balance => balance.denom === this.globalData.kichain.udenom).amount);
         }
 
         const responseDelegations = await services.wallet.fetchDelegatorsDelegationsList(

--- a/app/src/components/private-layout/topbar/no-wallet-actions.vue
+++ b/app/src/components/private-layout/topbar/no-wallet-actions.vue
@@ -204,8 +204,8 @@ export default {
         const responseBalances = await services.wallet.fetchBalancesList(
           this.wallets[w].address,
         );
-        if(responseBalances.data.result[0]){
-          total += parseInt(responseBalances.data.result[0].amount)
+        if(responseBalances.data.result.length){
+          total += parseInt(responseBalances.data.result.find(balance => balance.denom === 'uxdki').amount);
         }
 
         const responseDelegations = await services.wallet.fetchDelegatorsDelegationsList(

--- a/app/src/store/wallets/actions.js
+++ b/app/src/store/wallets/actions.js
@@ -13,6 +13,7 @@ export const FETCH_WALLET_BALANCES = 'FETCH_WALLET_BALANCES';
 export const FETCH_WALLET_VALIDATORS = 'FETCH_WALLET_VALIDATORS';
 export const FETCH_WALLET_REWARDS = 'FETCH_WALLET_REWARDS';
 
+import config from '@static/js/config';
 import util from '@static/js/util';
 import { tokenUtil } from '@static/js/token';
 

--- a/app/src/store/wallets/actions.js
+++ b/app/src/store/wallets/actions.js
@@ -349,8 +349,8 @@ export const actions = {
       }
 
 
-      if (responseBalances.data.result[0]) {
-        available = parseInt(responseBalances.data.result[0].amount)
+      if (responseBalances.data.result.length) {
+        available = parseInt(responseBalances.data.result.find(balance => balance.denom === 'uxki').amount);
       }
 
       if (responseDelegation.data.result[0]) {

--- a/app/src/store/wallets/actions.js
+++ b/app/src/store/wallets/actions.js
@@ -350,7 +350,7 @@ export const actions = {
 
 
       if (responseBalances.data.result.length) {
-        available = parseInt(responseBalances.data.result.find(balance => balance.denom === 'uxki').amount);
+        available = parseInt(responseBalances.data.result.find(balance => balance.denom === config.kichain.udenom).amount);
       }
 
       if (responseDelegation.data.result[0]) {


### PR DESCRIPTION
Issue in TKI desktop wallet total balances + wallet selected available balances.

Some users send messages on Telegram to submit an issue with the balance available.

The Desktop Wallet show the first balance of the endpoint https://api-wallet.blockchain.ki/bank/balances/ki1xxxxx

If the wallet have multiple balances, they show the first index (example with Atom here ) : 

![Capture d’écran 2023-01-04 à 13 27 03](https://user-images.githubusercontent.com/3876561/210559679-f5b07147-8c2a-4419-bb69-7432627ae3e5.png)


I made this pull request to replace first index to the uxki Index. 